### PR TITLE
feat: support checking local package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Are you considering converting your JavaScript project to TypeScript and you're 
 npx find-types <name of your npm module>
 ```
 
+> Note: If you do not include a module name argument, find=types will look for a package.json file in the current working directory to check for type definition availability
+
 ## How it works
 
 1. `find-types` scans your package's dependencies.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Are you considering converting your JavaScript project to TypeScript and you're 
 npx find-types <name of your npm module>
 ```
 
-> Note: If you do not include a module name argument, find=types will look for a package.json file in the current working directory to check for type definition availability
+> If you don't specify a module name, find-types will work with the project in the current working directory, if one exists.
 
 ## How it works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "find-types",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-types",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Find which of your module's dependencies have TypeScript types available",
   "main": "index.js",
   "keywords": [

--- a/util.js
+++ b/util.js
@@ -1,11 +1,14 @@
+const path = require("path");
 const got = require("got");
 
 const getDependenciesWithTypes = async (packageName, version) => {
   if (!packageName) {
-    throw new Error("Package name missing");
+    console.warn("\nPackage name missing, looking for local package.json");
   }
 
-  const package = await getPackageJson(packageName, version);
+  const package = packageName
+    ? await getPackageJson(packageName, version)
+    : readPackageJson();
 
   if (!package) {
     throw new Error("Package not found");
@@ -34,6 +37,18 @@ const getPackageJson = async (packageName, version) => {
     const tag = version === undefined ? body["dist-tags"].latest : version;
     const { dependencies, types } = body.versions[tag];
 
+    return { dependencies, types };
+  } catch (error) {
+    return null;
+  }
+};
+
+const readPackageJson = () => {
+  try {
+    const { dependencies, types } = require(path.join(
+      process.cwd(),
+      `./package.json`
+    ));
     return { dependencies, types };
   } catch (error) {
     return null;

--- a/util.js
+++ b/util.js
@@ -1,11 +1,6 @@
-const path = require("path");
 const got = require("got");
 
 const getDependenciesWithTypes = async (packageName, version) => {
-  if (!packageName) {
-    console.warn("\nPackage name missing, looking for local package.json");
-  }
-
   const package = packageName
     ? await getPackageJson(packageName, version)
     : readPackageJson();
@@ -45,10 +40,7 @@ const getPackageJson = async (packageName, version) => {
 
 const readPackageJson = () => {
   try {
-    const { dependencies, types } = require(path.join(
-      process.cwd(),
-      `./package.json`
-    ));
+    const { dependencies, types } = require(`./package.json`);
     return { dependencies, types };
   } catch (error) {
     return null;


### PR DESCRIPTION
Added a simple utility function to check the current working directory for a package.json file and a simple branch to invoke this function when the user omits a module name.